### PR TITLE
Lobby list

### DIFF
--- a/bin/main_client.ml
+++ b/bin/main_client.ml
@@ -6,6 +6,7 @@ let () =
     match Client_arg.parse_args () with
     | Client_arg.Join id -> Client.join_game (Notty_lwt.Term.create ()) id
     | Client_arg.Test config -> Client.offline_game (Notty_lwt.Term.create ()) config
+    | Client_arg.List -> Client.list_lobbies ()
     | Client_arg.Create config ->
       Client.create_game config
       >>= (function

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -11,22 +11,23 @@ let create_animated_fog x y center_x center_y =
   let time = Unix.time () in
   let noise_x = float_of_int (x + center_x) in
   let noise_y = float_of_int (y + center_y) in
-  let noise_value = 
-    sin (time *. 0.5 +. noise_x *. 0.1 +. noise_y *. 0.1) *. 0.1 +.
-    sin (time *. 0.3 +. noise_x *. 0.05) *. 0.05 +.
-    cos (time *. 0.7 +. noise_y *. 0.08) *. 0.03
+  let noise_value =
+    (sin ((time *. 0.5) +. (noise_x *. 0.1) +. (noise_y *. 0.1)) *. 0.1)
+    +. (sin ((time *. 0.3) +. (noise_x *. 0.05)) *. 0.05)
+    +. (cos ((time *. 0.7) +. (noise_y *. 0.08)) *. 0.03)
   in
   let fog_alpha = 0.8 +. noise_value in
   (`Fog, Base.Float.clamp_exn fog_alpha ~min:0.6 ~max:1.0, `Default)
 ;;
-
 
 let render_relative terminal Game.WireFormat.{ entities; _ } =
   let window_height, window_width = (21, 21) in
   let center_x, center_y = (window_width / 2, window_height / 2) in
   let entities_set =
     Map.of_list
-      (List.map (fun entity -> ((entity.Game.WireFormat.x, entity.Game.WireFormat.y), entity)) entities)
+      (List.map
+         (fun entity -> ((entity.Game.WireFormat.x, entity.Game.WireFormat.y), entity))
+         entities)
   in
   let image =
     I.tabulate (window_width * 2) window_height
@@ -38,13 +39,13 @@ let render_relative terminal Game.WireFormat.{ entities; _ } =
       match Map.find_opt (x, y) entities_set with
       | Some { entity_type; theme; _ } ->
         (* Server sent an entity for this position - render with distance-based alpha *)
-        let tile = 
+        let tile =
           match entity_type with
           | `Player player_type -> (player_type :> World.tile)
           | `Environment env_type -> (env_type :> World.tile)
         in
         (tile, 1.0, theme)
-      | None -> 
+      | None ->
         (* No entity sent by server for this position - render animated fog *)
         create_animated_fog x y center_x center_y
     in
@@ -81,7 +82,7 @@ let receive terminal message =
 ;;
 
 let create_game config =
-  let open Lwt.Infix in 
+  let open Lwt.Infix in
   let url = Config.server_url ^ "/create_game" in
   Network.HttpClient.post url (`CreateGame config)
   >>= function
@@ -96,27 +97,29 @@ let list_lobbies () =
   let url = Config.server_url ^ "/lobbies" in
   Network.HttpClient.get url
   >>= function
-  | Ok (`Lobbies lobbies) -> 
+  | Ok (`Lobbies lobbies) ->
     (match lobbies with
      | [] -> print_endline "No lobbies available."
-     | _ -> 
+     | _ ->
        print_endline "Available Lobbies:";
-       List.iter (fun (lobby : Game.WireFormat.lobby_info) ->
-         Printf.printf "Game %d: %d/%d players (%s)\n" 
-           lobby.game_id 
-           lobby.current_players 
-           lobby.max_players 
-           lobby.config_preview
-       ) lobbies;
+       List.iter
+         (fun (lobby : Game.WireFormat.lobby_info) ->
+           Printf.printf
+             "Game %d: %d/%d players (%s)\n"
+             lobby.game_id
+             lobby.current_players
+             lobby.max_players
+             lobby.config_preview)
+         lobbies;
        print_endline "\nUse: dune exec client -- join <game_id>");
     Lwt.return_unit
-  | Ok (`HttpError msg) -> 
+  | Ok (`HttpError msg) ->
     Printf.printf "Server error: %s\n" msg;
     Lwt.return_unit
   | Ok _ ->
     Printf.printf "Unexpected response type\n";
     Lwt.return_unit
-  | Error err -> 
+  | Error err ->
     Printf.printf "Error fetching lobbies: %s\n" (Http.Raw_client.show_error err);
     Lwt.return_unit
 ;;

--- a/lib/client.ml
+++ b/lib/client.ml
@@ -81,21 +81,22 @@ let receive terminal message =
 ;;
 
 let create_game config =
-  let open Lwt.Infix in
-  let open Game.WireFormat in
+  let open Lwt.Infix in 
   let url = Config.server_url ^ "/create_game" in
-  Http.Raw_client.post url (Serializer.string_of_config config)
-  >>= fun s -> Result.map Serializer.game_of_string s |> Lwt.return
+  Network.HttpClient.post url (`CreateGame config)
+  >>= function
+  | Ok (`GameCreated game) -> Lwt.return (Ok game)
+  | Ok (`HttpError msg) -> Lwt.return (Error (`ClientError (400, msg)))
+  | Ok _ -> Lwt.return (Error (`UnexpectedError (500, "Invalid response type")))
+  | Error err -> Lwt.return (Error err)
 ;;
 
 let list_lobbies () =
   let open Lwt.Infix in
-  let open Game.WireFormat in
   let url = Config.server_url ^ "/lobbies" in
-  Http.Raw_client.get url
+  Network.HttpClient.get url
   >>= function
-  | Ok body -> 
-    let lobbies = Serializer.lobby_list_of_string body in
+  | Ok (`Lobbies lobbies) -> 
     (match lobbies with
      | [] -> print_endline "No lobbies available."
      | _ -> 
@@ -108,6 +109,12 @@ let list_lobbies () =
            lobby.config_preview
        ) lobbies;
        print_endline "\nUse: dune exec client -- join <game_id>");
+    Lwt.return_unit
+  | Ok (`HttpError msg) -> 
+    Printf.printf "Server error: %s\n" msg;
+    Lwt.return_unit
+  | Ok _ ->
+    Printf.printf "Unexpected response type\n";
     Lwt.return_unit
   | Error err -> 
     Printf.printf "Error fetching lobbies: %s\n" (Http.Raw_client.show_error err);

--- a/lib/client_arg.ml
+++ b/lib/client_arg.ml
@@ -4,6 +4,7 @@ type command =
   | Create of Game.WireFormat.config
   | Join of int
   | Test of Game.WireFormat.config
+  | List
 
 let game_config_term =
   let open Game.WireFormat in
@@ -41,11 +42,7 @@ let game_config_term =
     Arg.(value & opt float default & info [ short; long ] ~doc)
   in
   let width =
-    opt_int
-      ~short:"w"
-      ~long:"width"
-      Config.default_game_config.width
-      "Width of the game"
+    opt_int ~short:"w" ~long:"width" Config.default_game_config.width "Width of the game"
   in
   let height =
     opt_int
@@ -144,6 +141,7 @@ let join_term =
 
 let create_term = Term.(const (fun config -> Create config) $ game_config_term)
 let test_term = Term.(const (fun config -> Test config) $ game_config_term)
+let list_term = Term.(const List)
 
 let join_cmd =
   let info = Cmd.info "join" ~doc:"Join a game by ID" in
@@ -160,9 +158,14 @@ let test_cmd =
   Cmd.v info test_term
 ;;
 
+let list_cmd =
+  let info = Cmd.info "list" ~doc:"List available lobbies waiting for players" in
+  Cmd.v info list_term
+;;
+
 let main_cmd =
   let info = Cmd.info "client" ~version:"1.0" ~doc:"Multiplayer game client" in
-  Cmd.group info [ join_cmd; create_cmd; test_cmd ]
+  Cmd.group info [ join_cmd; create_cmd; test_cmd; list_cmd ]
 ;;
 
 let parse_args () =

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -10,27 +10,28 @@ module Start = struct
     in
     let add_windows_to_segment wall_segment =
       let length = List.length wall_segment in
-      if length <= 2 || Random.float 1.0 > window_probability then
-        wall_segment (* No windows for short segments or by chance *)
-      else
-        let num_windows = Random.int 2 + 1 in (* 1-2 windows *)
-        let window_positions = 
+      if length <= 2 || Random.float 1.0 > window_probability
+      then wall_segment (* No windows for short segments or by chance *)
+      else (
+        let num_windows = Random.int 2 + 1 in
+        (* 1-2 windows *)
+        let window_positions =
           (* Only place windows in middle positions, not at ends *)
           let middle_positions = List.init (length - 2) (fun i -> i + 1) in
           let shuffled = List.sort (fun _ _ -> Random.int 3 - 1) middle_positions in
           let rec take n lst acc =
             match (n, lst) with
-            | (0, _) | (_, []) -> List.rev acc
-            | (n, x :: xs) -> take (n - 1) xs (x :: acc)
+            | 0, _ | _, [] -> List.rev acc
+            | n, x :: xs -> take (n - 1) xs (x :: acc)
           in
           take (min num_windows (List.length shuffled)) shuffled []
         in
-        List.mapi (fun i wall_entity ->
-          if List.mem i window_positions then
-            Game.{ wall_entity with entity_type = `Environment `Glass }
-          else
-            wall_entity
-        ) wall_segment
+        List.mapi
+          (fun i wall_entity ->
+            if List.mem i window_positions
+            then Game.{ wall_entity with entity_type = `Environment `Glass }
+            else wall_entity)
+          wall_segment)
     in
     let rec generate_random_walls_per_floor z n acc =
       if n <= 0

--- a/lib/game.atd
+++ b/lib/game.atd
@@ -40,3 +40,12 @@ type move =
   | Left
   | Right
   ]
+
+type lobby_info = {
+  game_id : int;
+  current_players : int;
+  max_players : int;
+  config_preview : string;
+}
+
+type lobby_list = lobby_info list

--- a/lib/game.ml
+++ b/lib/game.ml
@@ -11,13 +11,13 @@ let entity_id_gen = Uuid.create_gen ()
 type config = WireFormat.config
 
 (* Server-side entity with absolute coordinates for game logic *)
-type server_entity = {
-  entity_type : WireFormat.entity_type;
-  id : int;
-  x : int;
-  y : int;
-  z : int;
-}
+type server_entity =
+  { entity_type : WireFormat.entity_type;
+    id : int;
+    x : int;
+    y : int;
+    z : int
+  }
 
 type entity = server_entity
 
@@ -46,12 +46,9 @@ module Set3d = Set.Make (struct
   end)
 
 let gather_positions ~p ~entities =
-  Base.Hashtbl.fold
-    entities
-    ~init:Set3d.empty
-    ~f:(fun ~key:_ ~data positions ->
-      let { entity_type; x; y; z; _ } = data in
-      if p entity_type then Set3d.add (x, y, z) positions else positions)
+  Base.Hashtbl.fold entities ~init:Set3d.empty ~f:(fun ~key:_ ~data positions ->
+    let { entity_type; x; y; z; _ } = data in
+    if p entity_type then Set3d.add (x, y, z) positions else positions)
 ;;
 
 let get_players game =
@@ -61,7 +58,6 @@ let get_players game =
     | `Player _ -> Some e
     | _ -> None)
 ;;
-
 
 module Set2d = Set.Make (struct
     type t = int * int
@@ -89,29 +85,27 @@ let propagation_costs entities =
 let raycast_visibility ~pos:(px, py, pz) ~energy ~propagation_costs =
   let num_rays = 32 in
   let angle_step = 2.0 *. Float.pi /. float_of_int num_rays in
-  
   let cast_ray angle =
     let dx, dy = (cos angle, sin angle) in
     let rec step fx fy energy acc =
       let x, y = (int_of_float (fx +. 0.5), int_of_float (fy +. 0.5)) in
       let cost = Costs.find_opt (x, y, pz) propagation_costs |> Option.value ~default:0 in
       let new_acc = (x, y) :: acc in
-      if cost >= 1000 || energy - cost <= 0 then new_acc
-      else step (fx +. dx *. 0.5) (fy +. dy *. 0.5) (energy - cost - 1) new_acc
+      if cost >= 1000 || energy - cost <= 0
+      then new_acc
+      else step (fx +. (dx *. 0.5)) (fy +. (dy *. 0.5)) (energy - cost - 1) new_acc
     in
     step (float_of_int px) (float_of_int py) energy []
   in
-  
   List.init num_rays (fun i -> float_of_int i *. angle_step)
   |> List.fold_left (fun acc angle -> List.rev_append (cast_ray angle) acc) []
   |> List.sort_uniq compare
 ;;
 
-
 let visible_map_relative id game =
   let player_entity = find_entity_exn game id in
   let { x = px; y = py; z = pz; _ } = player_entity in
-  let energy = 
+  let energy =
     match player_entity.entity_type with
     | `Player `Human -> game.config.human_view_radius
     | `Player `Zombie -> game.config.zombie_view_radius
@@ -119,19 +113,16 @@ let visible_map_relative id game =
   in
   let propagation_costs = propagation_costs game.entities in
   let positions_to_send =
-    raycast_visibility ~pos:(px, py, pz) ~energy ~propagation_costs
-    |> Set2d.of_list
+    raycast_visibility ~pos:(px, py, pz) ~energy ~propagation_costs |> Set2d.of_list
   in
   let theme = Theme.get_theme_by_index pz in
   (* Create a set of positions that have real entities *)
-  let real_entities_positions = 
+  let real_entities_positions =
     game.entities
     |> Base.Hashtbl.data
     |> List.filter (fun ({ z; _ } : entity) -> z = pz)
-    |> List.fold_left (fun acc ({ x; y; _ } : entity) -> 
-        Set2d.add (x, y) acc) Set2d.empty
+    |> List.fold_left (fun acc ({ x; y; _ } : entity) -> Set2d.add (x, y) acc) Set2d.empty
   in
-  
   let visible_entities =
     game.entities
     |> Base.Hashtbl.data
@@ -140,51 +131,60 @@ let visible_map_relative id game =
     |> List.map (fun ({ entity_type; id; x; y; _ } : entity) ->
       WireFormat.{ entity_type; id; x = x - px; y = y - py; theme })
   in
-  
   (* Generate floor entities and boundary walls for all visible positions *)
-  let generated_entities = 
+  let generated_entities =
     let entities = ref [] in
-    let entity_id = ref (-1) in (* Counter for virtual entity IDs *)
-    
+    let entity_id = ref (-1) in
+    (* Counter for virtual entity IDs *)
+
     (* Generate virtual entity with unique ID *)
     let make_virtual_entity entity_type rx ry =
       decr entity_id;
-      WireFormat.{ 
-        entity_type; 
-        id = !entity_id; (* Use negative IDs for virtual entities *)
-        x = rx; y = ry; theme 
-      }
+      WireFormat.
+        { entity_type;
+          id = !entity_id;
+          (* Use negative IDs for virtual entities *)
+          x = rx;
+          y = ry;
+          theme
+        }
     in
-    
     (* Check each position in the visible area *)
-    Set2d.iter (fun (gx, gy) ->
-      let rx = gx - px in
-      let ry = gy - py in
-      
-      (* Check if this position is at the immediate map boundary (single edge layer) *)
-      let is_boundary_edge = 
-        (gx = -1 && gy >= 0 && gy < game.config.height) ||           (* Left edge *)
-        (gx = game.config.width && gy >= 0 && gy < game.config.height) || (* Right edge *)
-        (gy = -1 && gx >= 0 && gx < game.config.width) ||            (* Top edge *)
-        (gy = game.config.height && gx >= 0 && gx < game.config.width) || (* Bottom edge *)
-        (gx = -1 && gy = -1) ||                                      (* Top-left corner *)
-        (gx = -1 && gy = game.config.height) ||                      (* Bottom-left corner *)
-        (gx = game.config.width && gy = -1) ||                       (* Top-right corner *)
-        (gx = game.config.width && gy = game.config.height)          (* Bottom-right corner *)
-      in
-      
-      if is_boundary_edge then
-        (* Generate boundary wall only at immediate edge *)
-        entities := (make_virtual_entity (`Environment `Wall) rx ry) :: !entities
-      else if (gx >= 0 && gx < game.config.width && gy >= 0 && gy < game.config.height) 
-              && not (Set2d.mem (gx, gy) real_entities_positions) then
-        (* Generate floor for empty visible positions inside the map only *)
-        entities := (make_virtual_entity (`Environment `Floor) rx ry) :: !entities
-    ) positions_to_send;
-    
+    Set2d.iter
+      (fun (gx, gy) ->
+        let rx = gx - px in
+        let ry = gy - py in
+        (* Check if this position is at the immediate map boundary (single edge layer) *)
+        let is_boundary_edge =
+          (gx = -1 && gy >= 0 && gy < game.config.height)
+          (* Left edge *)
+          || (gx = game.config.width && gy >= 0 && gy < game.config.height)
+          (* Right edge *)
+          || (gy = -1 && gx >= 0 && gx < game.config.width)
+          (* Top edge *)
+          || (gy = game.config.height && gx >= 0 && gx < game.config.width)
+          (* Bottom edge *)
+          || (gx = -1 && gy = -1)
+          (* Top-left corner *)
+          || (gx = -1 && gy = game.config.height)
+          (* Bottom-left corner *)
+          || (gx = game.config.width && gy = -1)
+          || (* Top-right corner *)
+          (gx = game.config.width && gy = game.config.height)
+          (* Bottom-right corner *)
+        in
+        if is_boundary_edge
+        then
+          (* Generate boundary wall only at immediate edge *)
+          entities := make_virtual_entity (`Environment `Wall) rx ry :: !entities
+        else if (gx >= 0 && gx < game.config.width && gy >= 0 && gy < game.config.height)
+                && not (Set2d.mem (gx, gy) real_entities_positions)
+        then
+          (* Generate floor for empty visible positions inside the map only *)
+          entities := make_virtual_entity (`Environment `Floor) rx ry :: !entities)
+      positions_to_send;
     !entities
   in
-  
   visible_entities @ generated_entities
 ;;
 
@@ -238,9 +238,8 @@ let verify_end_conditions game start_time =
   in
   let now = Unix.time () in
   if int_of_float (now -. start_time) >= game.config.time_limit
-  then
-    Some (Win `Human)
-    else if all_zombie game.entities
-       then Some (Win `Zombie)
+  then Some (Win `Human)
+  else if all_zombie game.entities
+  then Some (Win `Zombie)
   else None
 ;;

--- a/lib/http/client.ml
+++ b/lib/http/client.ml
@@ -1,0 +1,28 @@
+module type Serializer = sig
+  type request
+  type response
+
+  val serialize_request : request -> string
+  val deserialize_response : string -> response
+end
+
+module Make (S : Serializer) = struct
+  type t = unit
+
+  let request (url : string) (req : S.request option)
+    : (S.response, Raw_client.error) result Lwt.t
+    =
+    let open Lwt.Infix in
+    match req with
+    | None -> Raw_client.get url >|= Result.map S.deserialize_response
+    | Some req ->
+      let serialized = S.serialize_request req in
+      Raw_client.post url serialized >|= Result.map S.deserialize_response
+  ;;
+
+  let get (url : string) : (S.response, Raw_client.error) result Lwt.t = request url None
+
+  let post (url : string) (req : S.request) : (S.response, Raw_client.error) result Lwt.t =
+    request url (Some req)
+  ;;
+end

--- a/lib/http/client.mli
+++ b/lib/http/client.mli
@@ -1,0 +1,14 @@
+module type Serializer = sig
+  type request
+  type response
+
+  val serialize_request : request -> string
+  val deserialize_response : string -> response
+end
+
+module Make (S : Serializer) : sig
+  type t = unit
+
+  val get : string -> (S.response, Raw_client.error) result Lwt.t
+  val post : string -> S.request -> (S.response, Raw_client.error) result Lwt.t
+end

--- a/lib/http/dune
+++ b/lib/http/dune
@@ -1,6 +1,6 @@
 (library
  (name http)
- (modules raw_client)
+ (modules raw_client client)
  (libraries websocket-lwt-unix lwt.unix dream)
  (preprocess
   (pps lwt_ppx)))

--- a/lib/message.atd
+++ b/lib/message.atd
@@ -1,6 +1,8 @@
 type game <ocaml from="Game"> = abstract
 type move <ocaml from="Game"> = abstract
 type character_type <ocaml from="Game"> = abstract
+type config <ocaml from="Game"> = abstract
+type lobby_list <ocaml from="Game"> = abstract
 
 type server_message = [ 
     | Update of game
@@ -13,5 +15,16 @@ type server_message = [
 type client_message = [ 
     | Move of move
     | Quit
+]
+
+type http_request = [
+    | GetLobbies
+    | CreateGame of config
+]
+
+type http_response = [
+    | Lobbies of lobby_list
+    | GameCreated of game
+    | HttpError of string
 ]
  

--- a/lib/network.ml
+++ b/lib/network.ml
@@ -1,9 +1,15 @@
-module TypedSerializer = struct
-  type message_in = Message.server_message
-  type message_out = Message.client_message
+module WsClient = Ws.Client.Make (struct
+    type message_in = Message.server_message
+    type message_out = Message.client_message
 
-  let serialize mess = Message.string_of_client_message mess
-  let deserialize = Message.server_message_of_string
-end
+    let serialize mess = Message.string_of_client_message mess
+    let deserialize = Message.server_message_of_string
+  end)
 
-module WsClient = Ws.Client.Make (TypedSerializer)
+module HttpClient = Http.Client.Make (struct
+    type request = Message.http_request
+    type response = Message.http_response
+
+    let serialize_request req = Message.string_of_http_request req
+    let deserialize_response = Message.http_response_of_string
+  end)

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -10,26 +10,20 @@ let send socket message =
 let game_update_message ?player_id game =
   let entities =
     match player_id with
-    | None -> 
+    | None ->
       (* For global view, convert all server entities to wire entities *)
       game.Game.entities
-      |> Base.Hashtbl.data 
+      |> Base.Hashtbl.data
       |> List.map ~f:(fun ({ entity_type; id; x; y; _ } : Game.entity) ->
-          Game.WireFormat.{ entity_type; id; x; y; theme = game.Game.config.theme_name })
+        Game.WireFormat.{ entity_type; id; x; y; theme = game.Game.config.theme_name })
     | Some id -> Game.visible_map_relative id game
   in
-  `Update
-    (Game.WireFormat.wire_format
-       ~game_id:game.game_id
-       ~entities)
+  `Update (Game.WireFormat.wire_format ~game_id:game.game_id ~entities)
 ;;
 
 let game_update_message_for_player player_id game =
   let relative_entities = Game.visible_map_relative player_id game in
-  `Update
-    (Game.WireFormat.wire_format
-       ~game_id:game.game_id
-       ~entities:relative_entities)
+  `Update (Game.WireFormat.wire_format ~game_id:game.game_id ~entities:relative_entities)
 ;;
 
 let receive socket =
@@ -137,7 +131,8 @@ let run () =
           @@ fun request ->
           let%lwt body = Dream.body request in
           let http_request = Message.http_request_of_string body in
-          let config = match http_request with
+          let config =
+            match http_request with
             | `CreateGame config -> config
             | `GetLobbies -> failwith "Invalid request type for /create_game"
           in

--- a/lib/server.ml
+++ b/lib/server.ml
@@ -141,6 +141,10 @@ let run () =
             Match.Registry.new_match config match_orchestrator |> game_update_message
           in
           Dream.respond @@ Game.WireFormat.Serializer.string_of_game game);
+         (Dream.get "/lobbies"
+          @@ fun _ ->
+          let lobbies = Match.Registry.list_waiting_matches () in
+          Dream.respond @@ Game.WireFormat.Serializer.string_of_lobby_list lobbies);
          (Dream.get "/join/:id"
           @@ fun request ->
           let id = Dream.param request "id" |> Int.of_string in


### PR DESCRIPTION
## Summary

  Add lobby listing functionality with typed HTTP client architecture. Players can now view available game lobbies before joining,
  and the codebase has been modernized with a unified, type-safe HTTP communication system.

###  Key Features Added

  - Lobby Listing: New dune exec client -- list command shows available waiting lobbies with player counts and game configurations
  - Typed HTTP Client: Complete HTTP client architecture mirroring the existing WebSocket client pattern
  - Unified Serialization: Consistent ATD-based message format for both HTTP and WebSocket communication

###    Technical Improvements

  - Extended message.atd with http_request and http_response types for type-safe HTTP communication
  - Created generic HTTP client library with Make functor pattern in lib/http/
  - Added Network.HttpClient alongside existing WsClient for consistent network abstraction
  - Replaced raw HTTP calls with typed client throughout codebase
  - Added proper error handling with HttpError variants

  New CLI Commands

  ### List available lobbies
  dune exec client -- list

  ###   Output example:
  Available Lobbies:
  Game 1: 1/4 players (30x30, view_radius=6)
  Game 2: 0/2 players (20x20, view_radius=4)

  Use: dune exec client -- join <game_id>

  API Changes

  - New endpoint: GET /lobbies returns list of waiting games
  - Updated endpoint: /create_game now uses unified request/response format